### PR TITLE
Support for AUTH packets

### DIFF
--- a/mqtt-sn-client/src/main/java/org/slj/mqtt/sn/client/impl/MqttsnClient.java
+++ b/mqtt-sn-client/src/main/java/org/slj/mqtt/sn/client/impl/MqttsnClient.java
@@ -171,9 +171,12 @@ public class MqttsnClient extends AbstractMqttsnRuntime implements IMqttsnClient
             if (session.getClientState() != ClientState.ACTIVE) {
                 startProcessing(false);
                 try {
+                    MqttsnSecurityOptions securityOptions = registry.getOptions().getSecurityOptions();
                     IMqttsnMessage message = registry.getMessageFactory().createConnect(
                             registry.getOptions().getContextId(), keepAlive,
-                            registry.getWillRegistry().hasWillMessage(session), cleanSession,
+                            registry.getWillRegistry().hasWillMessage(session),
+                            (securityOptions != null && securityOptions.getAuthHandler() != null),
+                            cleanSession,
                             registry.getOptions().getMaxProtocolMessageSize(),
                             registry.getOptions().getDefaultMaxAwakeMessages(),
                             registry.getOptions().getSessionExpiryInterval());

--- a/mqtt-sn-client/src/main/java/org/slj/mqtt/sn/client/spi/SaslAuthHandler.java
+++ b/mqtt-sn-client/src/main/java/org/slj/mqtt/sn/client/spi/SaslAuthHandler.java
@@ -1,0 +1,45 @@
+package org.slj.mqtt.sn.client.spi;
+
+import java.util.Map;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslException;
+import org.slj.mqtt.sn.model.IAuthHandler;
+
+public class SaslAuthHandler implements IAuthHandler {
+
+  private final SaslClient saslClient;
+  private final String mechanism;
+
+  public SaslAuthHandler(String mechanism, String authorisationId, String serverName, Map<String,?> props, CallbackHandler callbackHandler) throws SaslException {
+    this.mechanism = mechanism;
+    String[] mechanisms = {mechanism};
+    saslClient =  Sasl.createSaslClient(
+        mechanisms,
+        authorisationId,
+        "MQTT-SN",
+        serverName,
+        props,
+        callbackHandler);
+  }
+
+  @Override
+  public String getMechanism() {
+    return mechanism;
+  }
+
+  @Override
+  public boolean isComplete() {
+    return saslClient.isComplete();
+  }
+
+  @Override
+  public byte[] handleChallenge(byte[] challenge) throws SaslException {
+    if(!saslClient.isComplete()){
+      return saslClient.evaluateChallenge(challenge);
+    }
+    throw new SaslException("Challenge is complete");
+  }
+
+}

--- a/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/ExampleUsage.java
+++ b/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/ExampleUsage.java
@@ -44,7 +44,7 @@ public class ExampleUsage {
 
         //-- construct a connect message with your required configuration
         IMqttsnMessage connect =
-                factory.createConnect("testClientId", 60, false, true, 1024, 0, 0);
+                factory.createConnect("testClientId", 60, false, false,true, 1024, 0, 0);
 
         System.out.println(connect);
 

--- a/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/spi/IMqttsnMessageFactory.java
+++ b/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/spi/IMqttsnMessageFactory.java
@@ -37,6 +37,8 @@ import org.slj.mqtt.sn.codec.MqttsnCodecException;
  */
 public interface IMqttsnMessageFactory {
 
+    IMqttsnMessage createAuth(String method, byte[] data) throws MqttsnCodecException;
+
     /**
      * The ADVERTISE message is broadcasted periodically by a gateway to advertise its presence.
      * The time interval until the next broadcast time is indicated in the Duration field of this message.
@@ -82,7 +84,7 @@ public interface IMqttsnMessageFactory {
      * @param cleanSession: same meaning as with MQTT, however extended for Will topic and Will message.
      * @param defaultAwakeMessages: the default max number of messages transmitted per awake cycle.
      */
-    IMqttsnMessage createConnect(String clientId, int keepAlive, boolean willPrompt, boolean cleanSession, int maxPacketSize, int defaultAwakeMessages, long sessionExpiryInterval)
+    IMqttsnMessage createConnect(String clientId, int keepAlive, boolean willPrompt, boolean auth, boolean cleanSession, int maxPacketSize, int defaultAwakeMessages, long sessionExpiryInterval)
             throws MqttsnCodecException;
 
     /**

--- a/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/wire/version1_2/Mqttsn_v1_2_MessageFactory.java
+++ b/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/wire/version1_2/Mqttsn_v1_2_MessageFactory.java
@@ -51,6 +51,11 @@ public class Mqttsn_v1_2_MessageFactory extends AbstractMqttsnMessageFactory {
     }
 
     @Override
+    public IMqttsnMessage createAuth(String method, byte[] data) throws MqttsnCodecException {
+        throw new MqttsnCodecException("Version 1.2 does not support AUTH packets");
+    }
+
+    @Override
     public IMqttsnMessage createAdvertise(int gatewayId, int duration) throws MqttsnCodecException {
 
         MqttsnAdvertise msg = new MqttsnAdvertise();
@@ -80,7 +85,7 @@ public class Mqttsn_v1_2_MessageFactory extends AbstractMqttsnMessageFactory {
     }
 
     @Override
-    public IMqttsnMessage createConnect(String clientId, int keepAlive, boolean willPrompt, boolean cleanSession, int maxPacketSize, int defaultAwakeMessages, long sessionExpiryInterval) throws MqttsnCodecException {
+    public IMqttsnMessage createConnect(String clientId, int keepAlive, boolean willPrompt, boolean auth, boolean cleanSession, int maxPacketSize, int defaultAwakeMessages, long sessionExpiryInterval) throws MqttsnCodecException {
 
         MqttsnConnect msg = new MqttsnConnect();
         msg.setClientId(clientId);

--- a/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/wire/version2_0/Mqttsn_v2_0_MessageFactory.java
+++ b/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/wire/version2_0/Mqttsn_v2_0_MessageFactory.java
@@ -52,8 +52,14 @@ public class Mqttsn_v2_0_MessageFactory extends Mqttsn_v1_2_MessageFactory imple
         return instance;
     }
 
+
     @Override
-    public IMqttsnMessage createConnect(String clientId, int keepAlive, boolean willPrompt, boolean cleanSession, int maxPacketSize, int defaultAwakeMessages, long sessionExpiryInterval) throws MqttsnCodecException {
+    public IMqttsnMessage createAuth(String method, byte[] data) throws MqttsnCodecException {
+        return new MqttsnAuth(method, data);
+    }
+
+    @Override
+    public IMqttsnMessage createConnect(String clientId, int keepAlive, boolean willPrompt, boolean auth, boolean cleanSession, int maxPacketSize, int defaultAwakeMessages, long sessionExpiryInterval) throws MqttsnCodecException {
 
         MqttsnConnect_V2_0 msg = new MqttsnConnect_V2_0();
         msg.setClientId(clientId);
@@ -64,6 +70,7 @@ public class Mqttsn_v2_0_MessageFactory extends Mqttsn_v1_2_MessageFactory imple
         msg.setDefaultAwakeMessages(defaultAwakeMessages);
         msg.setSessionExpiryInterval(sessionExpiryInterval);
         msg.validate();
+        msg.setAuth(auth);
         return msg;
     }
 

--- a/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/wire/version2_0/payload/MqttsnAuth.java
+++ b/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/wire/version2_0/payload/MqttsnAuth.java
@@ -36,6 +36,16 @@ public class MqttsnAuth extends AbstractMqttsnMessage implements IMqttsnMessageV
     protected String authMethod;
     protected byte[] authData;
 
+    public MqttsnAuth(){
+
+    }
+
+    public MqttsnAuth(String authMethod, byte[] authData){
+        this.authMethod = authMethod;
+        authMethodLength = authMethod.length();
+        this.authData = authData;
+    }
+
     @Override
     public int getMessageType() {
         return MqttsnConstants.AUTH;

--- a/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/wire/version2_0/payload/MqttsnPublish_V2_0.java
+++ b/mqtt-sn-codec/src/main/java/org/slj/mqtt/sn/wire/version2_0/payload/MqttsnPublish_V2_0.java
@@ -73,9 +73,9 @@ public class MqttsnPublish_V2_0 extends AbstractMqttsnMessage implements IMqttsn
 
     protected void setTopicType(byte topicType) {
         if (topicType != MqttsnConstants.TOPIC_PREDEFINED &&
-                topicType != MqttsnConstants.TOPIC_NORMAL &&
-                topicType != MqttsnConstants.TOPIC_SHORT &&
-                topicType != MqttsnConstants.TOPIC_FULL) {
+            topicType != MqttsnConstants.TOPIC_NORMAL &&
+            topicType != MqttsnConstants.TOPIC_SHORT &&
+            topicType != MqttsnConstants.TOPIC_FULL) {
             throw new IllegalArgumentException("unable to set invalid topicIdType value on message " + topicType);
         }
         this.topicIdType = topicType;
@@ -216,13 +216,15 @@ public class MqttsnPublish_V2_0 extends AbstractMqttsnMessage implements IMqttsn
             msg[idx++] = (byte) (id & 0xFF);
         }
 
-        topicLength = topicLength == 0 ? topicIdType == MqttsnConstants.TOPIC_FULL ? topicData.length : 2 : 2;
-
         if(topicIdType == MqttsnConstants.TOPIC_FULL){
+            topicLength = topicLength == 0 ? topicIdType == MqttsnConstants.TOPIC_FULL ? topicData.length : 2 : 2;
             msg[idx++] = (byte) ((topicLength >> 8) & 0xFF);
             msg[idx++] = (byte) (topicLength & 0xFF);
-        } else {
             System.arraycopy(topicData, 0, msg, idx, topicData.length);
+        }
+        else{
+            msg[idx++] = topicData[0];
+            msg[idx++] = topicData[1];
         }
 
 

--- a/mqtt-sn-codec/src/test/java/org/slj/mqtt/sn/wire/version1_2/payload/Mqttsn1_2WireTests.java
+++ b/mqtt-sn-codec/src/test/java/org/slj/mqtt/sn/wire/version1_2/payload/Mqttsn1_2WireTests.java
@@ -72,7 +72,7 @@ public class Mqttsn1_2WireTests {
     public void testMqttsnConnect() throws MqttsnCodecException {
 
         //-- test normal length clientId
-        IMqttsnMessage message = factory.createConnect(_clientid, MqttsnConstants.UNSIGNED_MAX_16, false, true, 1024, 0, 0);
+        IMqttsnMessage message = factory.createConnect(_clientid, MqttsnConstants.UNSIGNED_MAX_16, false, false, true, 1024, 0, 0);
         testWireMessage(message);
     }
 
@@ -85,7 +85,7 @@ public class Mqttsn1_2WireTests {
             sb.append("A");
         }
 
-        IMqttsnMessage message = factory.createConnect(sb.toString(), MqttsnConstants.UNSIGNED_MAX_16, false, true, 1024, 0, 0);
+        IMqttsnMessage message = factory.createConnect(sb.toString(), MqttsnConstants.UNSIGNED_MAX_16, false, false, true, 1024, 0, 0);
         testWireMessage(message);
     }
 

--- a/mqtt-sn-codec/src/test/java/org/slj/mqtt/sn/wire/version2_0/payload/Mqttsn2_0WireTests.java
+++ b/mqtt-sn-codec/src/test/java/org/slj/mqtt/sn/wire/version2_0/payload/Mqttsn2_0WireTests.java
@@ -43,19 +43,19 @@ public class Mqttsn2_0WireTests extends Mqttsn1_2WireTests {
 
     @Test
     public void testMqttsnConnect() throws MqttsnCodecException {
-        IMqttsnMessage message = factory.createConnect("THIS-IS-CLIENT-ID",98, false, false, 500, 4, 5000);
+        IMqttsnMessage message = factory.createConnect("THIS-IS-CLIENT-ID",98, false, false, false, 500, 4, 5000);
         testWireMessage(message);
 
-        message = factory.createConnect("THIS-IS-CLIENT-ID",98, false, false, 500, 0, 5000);
+        message = factory.createConnect("THIS-IS-CLIENT-ID",98, false, false, false, 500, 0, 5000);
         testWireMessage(message);
     }
 
     @Test
     public void testMqttsnConnectNoClientId() throws MqttsnCodecException {
-        IMqttsnMessage message = factory.createConnect("",98, false, false, 500, 4, 5000);
+        IMqttsnMessage message = factory.createConnect("",98, false, false, false, 500, 4, 5000);
         testWireMessage(message);
 
-        message = factory.createConnect("",98, false, false, 500, 0, 5000);
+        message = factory.createConnect("",98, false, false, false, 500, 0, 5000);
         testWireMessage(message);
     }
 

--- a/mqtt-sn-core/src/main/java/org/slj/mqtt/sn/model/IAuthHandler.java
+++ b/mqtt-sn-core/src/main/java/org/slj/mqtt/sn/model/IAuthHandler.java
@@ -1,0 +1,13 @@
+package org.slj.mqtt.sn.model;
+
+import java.io.IOException;
+
+public interface IAuthHandler {
+
+  String getMechanism();
+
+  boolean isComplete();
+
+  byte[] handleChallenge(byte[] challenge) throws IOException;
+
+}

--- a/mqtt-sn-core/src/main/java/org/slj/mqtt/sn/model/MqttsnSecurityOptions.java
+++ b/mqtt-sn-core/src/main/java/org/slj/mqtt/sn/model/MqttsnSecurityOptions.java
@@ -59,6 +59,11 @@ public class MqttsnSecurityOptions {
      */
     public final String DEFAULT_INTEGRITY_KEY = "u6670-sddsd-22ys8uj";
 
+    /**
+     * If present, provides SASL Auth exchange
+     */
+    private IAuthHandler authHandler;
+
     private String integrityKey = DEFAULT_INTEGRITY_KEY;
     private INTEGRITY_TYPE integrityType = DEFAULT_INTEGRITY_TYPE;
     private INTEGRITY_POINT integrityPoint = DEFAULT_INTEGRITY_POINT;
@@ -85,6 +90,10 @@ public class MqttsnSecurityOptions {
         return integrityChecksumAlgorithm;
     }
 
+    public IAuthHandler getAuthHandler(){
+        return authHandler;
+    }
+
     public MqttsnSecurityOptions withIntegrityKey(String integrityKey){
         this.integrityKey = integrityKey;
         return this;
@@ -107,6 +116,11 @@ public class MqttsnSecurityOptions {
 
     public MqttsnSecurityOptions withIntegrityType(INTEGRITY_TYPE integrityType){
         this.integrityType = integrityType;
+        return this;
+    }
+
+    public MqttsnSecurityOptions withAuthHandler(IAuthHandler authHandler){
+        this.authHandler = authHandler;
         return this;
     }
 }

--- a/mqtt-sn-load-test/src/main/java/org/slj/mqtt/sn/load/tests/OpenConnectionNoStateTestMain.java
+++ b/mqtt-sn-load-test/src/main/java/org/slj/mqtt/sn/load/tests/OpenConnectionNoStateTestMain.java
@@ -62,7 +62,7 @@ public class OpenConnectionNoStateTestMain {
             try {
                 socket = new DatagramSocket(++localBindPort, null);
                 byte[] connect = MqttsnCodecs.MQTTSN_CODEC_VERSION_1_2.encode(MqttsnCodecs.MQTTSN_CODEC_VERSION_1_2.createMessageFactory().
-                        createConnect("" + localBindPort, 3600, false, true, 0, 0, 0));
+                        createConnect("" + localBindPort, 3600, false, false, true, 0, 0, 0));
                 DatagramPacket packet = new DatagramPacket(connect, connect.length, address, port);
                 socket.send(packet);
 


### PR DESCRIPTION
These changes allow a user to build an authentication mechanism on top of MQTT-SN using the AUTH packets.
A SASL implementation is provided but the interface could be used for any type of challenge - response authentication